### PR TITLE
Add PCA preprocessing option

### DIFF
--- a/AnythingToGif/AnythingToGif.csproj
+++ b/AnythingToGif/AnythingToGif.csproj
@@ -27,6 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="MathNet.Numerics" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AnythingToGif/CLI/Options.cs
+++ b/AnythingToGif/CLI/Options.cs
@@ -73,6 +73,9 @@ internal class Options {
   [Option('b', "firstSubImageInitsBackground", Default = true, HelpText = "Whether the first sub-image initializes the background.")]
   public bool FirstSubImageInitsBackground { get; set; }
 
+  [Option('p', "usePca", Default = false, HelpText = "Use PCA preprocessing before quantization.")]
+  public bool UsePca { get; set; }
+
   [Option('c', "colorOrdering", Default = ColorOrderingMode.MostUsedFirst, HelpText = "Color ordering mode.")]
   public ColorOrderingMode ColorOrdering { get; set; }
 
@@ -97,11 +100,15 @@ internal class Options {
     _ => throw new("Unknown color distance metric")
   };
 
-  public Func<IQuantizer> Quantizer => this._Quantizer switch {
-    QuantizerMode.Octree => () => new OctreeQuantizer(),
-    QuantizerMode.MedianCut => () => new MedianCutQuantizer(),
-    QuantizerMode.GreedyOrthogonalBiPartitioning => () => new WuQuantizer(),
-    _ => throw new("Unknown quantizer")
+  public Func<IQuantizer> Quantizer => () => {
+    IQuantizer q = this._Quantizer switch {
+      QuantizerMode.Octree => new OctreeQuantizer(),
+      QuantizerMode.MedianCut => new MedianCutQuantizer(),
+      QuantizerMode.GreedyOrthogonalBiPartitioning => new WuQuantizer(),
+      _ => throw new("Unknown quantizer")
+    };
+
+    return this.UsePca ? new PcaQuantizerWrapper(q) : q;
   };
 
   public IDitherer Ditherer => this._Ditherer switch {

--- a/AnythingToGif/Quantizers/PcaHelper.cs
+++ b/AnythingToGif/Quantizers/PcaHelper.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+using MathNet.Numerics.LinearAlgebra;
+
+namespace AnythingToGif.Quantizers;
+
+internal sealed class PcaHelper {
+  private readonly Vector<double> _mean;
+  private readonly Matrix<double> _eigenvectors;
+  private readonly double[] _min;
+  private readonly double[] _max;
+
+  public PcaHelper(IEnumerable<Color> colors) {
+    var builder = Vector<double>.Build;
+    var rows = colors.Select(c => builder.Dense([c.R, c.G, c.B])).ToList();
+    if (rows.Count == 0) {
+      this._mean = builder.Dense(3);
+      this._eigenvectors = Matrix<double>.Build.DenseIdentity(3);
+      this._min = [0, 0, 0];
+      this._max = [1, 1, 1];
+      return;
+    }
+
+    this._mean = rows.Aggregate(builder.Dense(3), (acc, v) => acc + v) / rows.Count;
+    var centered = rows.Select(v => v - this._mean).ToList();
+    var matrix = Matrix<double>.Build.DenseOfRowVectors(centered);
+    var cov = matrix.TransposeThisAndMultiply(matrix) / (rows.Count - 1.0);
+    var evd = cov.Evd();
+    this._eigenvectors = evd.EigenVectors;
+    var transformed = matrix * this._eigenvectors;
+
+    this._min = new double[3];
+    this._max = new double[3];
+    for (var i = 0; i < 3; ++i) {
+      var column = transformed.Column(i);
+      this._min[i] = column.Minimum();
+      this._max[i] = column.Maximum();
+      if (this._min[i] == this._max[i]) {
+        this._min[i] = 0;
+        this._max[i] = 1;
+      }
+    }
+  }
+
+  public IEnumerable<Color> TransformColors(IEnumerable<Color> colors) {
+    foreach (var c in colors)
+      yield return this.Transform(c);
+  }
+
+  public IEnumerable<Color> InverseTransformColors(IEnumerable<Color> colors) {
+    foreach (var c in colors)
+      yield return this.InverseTransform(c);
+  }
+
+  public Color Transform(Color color) {
+    var vec = Vector<double>.Build.Dense([color.R, color.G, color.B]);
+    var centered = vec - this._mean;
+    var t = centered * this._eigenvectors;
+    var r = ScaleToByte(t[0], 0);
+    var g = ScaleToByte(t[1], 1);
+    var b = ScaleToByte(t[2], 2);
+    return Color.FromArgb(r, g, b);
+  }
+
+  public Color InverseTransform(Color color) {
+    var t0 = Unscale(color.R, 0);
+    var t1 = Unscale(color.G, 1);
+    var t2 = Unscale(color.B, 2);
+    var vec = Vector<double>.Build.Dense([t0, t1, t2]);
+    var orig = this._mean + this._eigenvectors * vec;
+    return Color.FromArgb(Clamp((int)Math.Round(orig[0])), Clamp((int)Math.Round(orig[1])), Clamp((int)Math.Round(orig[2])));
+  }
+
+  private int ScaleToByte(double value, int index)
+    => Clamp((int)Math.Round((value - this._min[index]) / (this._max[index] - this._min[index]) * 255.0));
+
+  private double Unscale(int value, int index)
+    => value / 255.0 * (this._max[index] - this._min[index]) + this._min[index];
+
+  private static int Clamp(int v) => v < 0 ? 0 : v > 255 ? 255 : v;
+}

--- a/AnythingToGif/Quantizers/PcaQuantizerWrapper.cs
+++ b/AnythingToGif/Quantizers/PcaQuantizerWrapper.cs
@@ -1,0 +1,33 @@
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace AnythingToGif.Quantizers;
+
+public class PcaQuantizerWrapper : IQuantizer {
+  private readonly IQuantizer _inner;
+
+  public PcaQuantizerWrapper(IQuantizer inner) {
+    this._inner = inner;
+  }
+
+  public Color[] ReduceColorsTo(byte numberOfColors, IEnumerable<Color> usedColors) {
+    var colors = usedColors.ToList();
+    if (colors.Count == 0)
+      return [];
+    var pca = new PcaHelper(colors);
+    var transformed = pca.TransformColors(colors);
+    var quantized = this._inner.ReduceColorsTo(numberOfColors, transformed);
+    return pca.InverseTransformColors(quantized).ToArray();
+  }
+
+  public Color[] ReduceColorsTo(byte numberOfColors, IEnumerable<(Color color, uint count)> histogram) {
+    var colors = histogram.Select(h => h.color).ToList();
+    if (colors.Count == 0)
+      return [];
+    var pca = new PcaHelper(colors);
+    var transformed = histogram.Select(h => (pca.Transform(h.color), h.count));
+    var quantized = this._inner.ReduceColorsTo(numberOfColors, transformed);
+    return pca.InverseTransformColors(quantized).ToArray();
+  }
+}

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Usage: AnythingToGif [<input>] [<options>] | <input> <output> [<options>]
   -d, --ditherer                        (Default: FloydSteinberg) Ditherer to use.
   -f, --useBackFilling                  (Default: false) Whether to use backfilling.
   -b, --firstSubImageInitsBackground    (Default: true) Whether the first sub-image initializes the background.
+  -p, --usePca                           (Default: false) Use PCA preprocessing before quantization.
   -c, --colorOrdering                   (Default: MostUsedFirst) Color ordering mode.
   -n, --noCompression                   (Default: false) Whether to use compressed GIF files or not.
   --help                                Display this help screen.


### PR DESCRIPTION
## Summary
- add new `PcaQuantizerWrapper` and `PcaHelper` for PCA-based color preprocessing
- support optional `--usePca` flag in command line
- update project file for MathNet.Numerics
- document the new flag in `README`

## Testing
- `dotnet build AnythingToGif.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_68775d29b33883339dc023ea37afc61c