### PR TITLE
Add fixed palette quantizers

### DIFF
--- a/AnythingToGif/CLI/Options.cs
+++ b/AnythingToGif/CLI/Options.cs
@@ -14,7 +14,11 @@ internal class Options {
   public enum QuantizerMode {
     [Description("Median-Cut")] MedianCut,
     [Description("Octree")] Octree,
-    [Description("Greedy Orthogonal Bi-Partitioning (Wu)")] GreedyOrthogonalBiPartitioning
+    [Description("Greedy Orthogonal Bi-Partitioning (Wu)")] GreedyOrthogonalBiPartitioning,
+    [Description("EGA 16-colors + transparency")] Ega16,
+    [Description("VGA 256-colors + transparency")] Vga256,
+    [Description("Web Safe palette + transparency")] WebSafe,
+    [Description("Mac 8-bit system palette + transparency")] Mac8Bit
   }
 
   public enum DithererMode {
@@ -62,6 +66,10 @@ internal class Options {
     QuantizerMode.Octree => () => new OctreeQuantizer(),
     QuantizerMode.MedianCut => () => new MedianCutQuantizer(),
     QuantizerMode.GreedyOrthogonalBiPartitioning => () => new WuQuantizer(),
+    QuantizerMode.Ega16 => () => new Ega16Quantizer(),
+    QuantizerMode.Vga256 => () => new Vga256Quantizer(),
+    QuantizerMode.WebSafe => () => new WebSafeQuantizer(),
+    QuantizerMode.Mac8Bit => () => new Mac8BitQuantizer(),
     _ => throw new("Unknown quantizer")
   };
 

--- a/AnythingToGif/Quantizers/Ega16Quantizer.cs
+++ b/AnythingToGif/Quantizers/Ega16Quantizer.cs
@@ -1,0 +1,26 @@
+using System.Drawing;
+
+namespace AnythingToGif.Quantizers;
+
+public sealed class Ega16Quantizer : FixedPaletteQuantizer {
+  internal static readonly Color[] Palette = {
+    Color.FromArgb(0, 0, 0),
+    Color.FromArgb(0, 0, 170),
+    Color.FromArgb(0, 170, 0),
+    Color.FromArgb(0, 170, 170),
+    Color.FromArgb(170, 0, 0),
+    Color.FromArgb(170, 0, 170),
+    Color.FromArgb(170, 85, 0),
+    Color.FromArgb(170, 170, 170),
+    Color.FromArgb(85, 85, 85),
+    Color.FromArgb(85, 85, 255),
+    Color.FromArgb(85, 255, 85),
+    Color.FromArgb(85, 255, 255),
+    Color.FromArgb(255, 85, 85),
+    Color.FromArgb(255, 85, 255),
+    Color.FromArgb(255, 255, 85),
+    Color.FromArgb(255, 255, 255)
+  };
+
+  public Ega16Quantizer() : base(Palette) { }
+}

--- a/AnythingToGif/Quantizers/FixedPaletteQuantizer.cs
+++ b/AnythingToGif/Quantizers/FixedPaletteQuantizer.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Linq;
+
+namespace AnythingToGif.Quantizers;
+
+public abstract class FixedPaletteQuantizer : QuantizerBase {
+  private readonly Color[] _palette;
+
+  protected FixedPaletteQuantizer(IEnumerable<Color> palette) {
+    this._palette = palette.ToArray();
+  }
+
+  public override Color[] ReduceColorsTo(byte numberOfColors, IEnumerable<(Color color, uint count)> histogram) =>
+    this._palette.Take(numberOfColors).ToArray();
+}

--- a/AnythingToGif/Quantizers/Mac8BitQuantizer.cs
+++ b/AnythingToGif/Quantizers/Mac8BitQuantizer.cs
@@ -1,0 +1,21 @@
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace AnythingToGif.Quantizers;
+
+public sealed class Mac8BitQuantizer : FixedPaletteQuantizer {
+  private static Color[] _CreatePalette() {
+    var list = new List<Color>(256);
+    int[] rg = { 0, 36, 73, 109, 146, 182, 219, 255 };
+    int[] b = { 0, 85, 170, 255 };
+    foreach (var r in rg)
+      foreach (var g in rg)
+        foreach (var blue in b)
+          list.Add(Color.FromArgb(r, g, blue));
+    return list.ToArray();
+  }
+
+  private static readonly Color[] Palette = _CreatePalette();
+
+  public Mac8BitQuantizer() : base(Palette) { }
+}

--- a/AnythingToGif/Quantizers/Vga256Quantizer.cs
+++ b/AnythingToGif/Quantizers/Vga256Quantizer.cs
@@ -1,0 +1,25 @@
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace AnythingToGif.Quantizers;
+
+public sealed class Vga256Quantizer : FixedPaletteQuantizer {
+  private static Color[] _CreatePalette() {
+    var list = new List<Color>(256);
+    list.AddRange(Ega16Quantizer.Palette);
+    int[] steps = { 0, 51, 102, 153, 204, 255 };
+    foreach (var r in steps)
+      foreach (var g in steps)
+        foreach (var b in steps)
+          list.Add(Color.FromArgb(r, g, b));
+    for (var i = 0; i < 24; ++i) {
+      var v = 8 + i * 10;
+      list.Add(Color.FromArgb(v, v, v));
+    }
+    return list.ToArray();
+  }
+
+  private static readonly Color[] Palette = _CreatePalette();
+
+  public Vga256Quantizer() : base(Palette) { }
+}

--- a/AnythingToGif/Quantizers/WebSafeQuantizer.cs
+++ b/AnythingToGif/Quantizers/WebSafeQuantizer.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+using System.Drawing;
+
+namespace AnythingToGif.Quantizers;
+
+public sealed class WebSafeQuantizer : FixedPaletteQuantizer {
+  private static Color[] _CreatePalette() {
+    var list = new List<Color>(216);
+    int[] steps = { 0, 51, 102, 153, 204, 255 };
+    foreach (var r in steps)
+      foreach (var g in steps)
+        foreach (var b in steps)
+          list.Add(Color.FromArgb(r, g, b));
+    return list.ToArray();
+  }
+
+  private static readonly Color[] Palette = _CreatePalette();
+
+  public WebSafeQuantizer() : base(Palette) { }
+}

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ Quantizer Modes:
   MedianCut: Median-Cut
   Octree: Octree
   GreedyOrthogonalBiPartitioning: Greedy Orthogonal Bi-Partitioning (Wu)
+  Ega16: EGA 16-colors + transparency
+  Vga256: VGA 256-colors + transparency
+  WebSafe: Web Safe palette + transparency
+  Mac8Bit: Mac 8-bit system palette + transparency
 
 Ditherer Modes:
   None: None


### PR DESCRIPTION
## Summary
- add a fixed palette quantizer base class
- add EGA16, VGA256, WebSafe and Mac8Bit quantizers
- expose new quantizers as CLI options
- document new quantizers

## Testing
- `dotnet build AnythingToGif.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684944c0b7148333be2bf364ae026180